### PR TITLE
Chore/swagger docs

### DIFF
--- a/src/main/java/com/deadlock/hellocs/global/adapter/in/web/OAuth2AuthControllerDocs.java
+++ b/src/main/java/com/deadlock/hellocs/global/adapter/in/web/OAuth2AuthControllerDocs.java
@@ -1,0 +1,67 @@
+package com.deadlock.hellocs.global.adapter.in.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@Tag(name = "Auth", description = "인증")
+@RestController
+@RequestMapping("/api/v1/auth")
+public class OAuth2AuthControllerDocs {
+//Docs 용 Class 이므로 실제 작동 로직은 없음(Spring Security 에서 가로챔)
+
+    @Operation(
+            summary = "카카오 OAuth2 로그인",
+            description = """
+                    카카오 로그인 페이지로 이동합니다.
+
+                    **테스트 방법 (Swagger UI)**
+                    1. 아래 **Try it out → Execute** 버튼 클릭
+                    2. 브라우저에서 `http://localhost:8080/api/v1/auth/oauth2/kakao` 직접 접속
+                    3. 카카오 계정으로 로그인
+                    4. 로그인 성공 시 아래 형태의 JSON이 응답으로 반환됨
+                    5. `accessToken` 값을 복사
+                    6. Swagger UI 우측 상단 **Authorize 🔒** 버튼 클릭
+                    7. `bearerAuth` 항목에 복사한 `accessToken` 붙여넣기 → **Authorize**
+                    8. 이후 인증이 필요한 모든 API 테스트 가능
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그인 성공 — 응답 body에 JWT 포함",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = OAuth2LoginResponse.class),
+                    examples = @ExampleObject(value = """
+                            {
+                              "accessToken": "eyJhbGciOiJSUzI1NiJ9...",
+                              "refreshToken": "eyJhbGciOiJSUzI1NiJ9...",
+                              "isUser": true
+                            }
+                            """)
+            )
+    )
+    @GetMapping("/oauth2/kakao")
+    public void kakaoLogin(HttpServletResponse response) throws IOException {
+        response.sendRedirect("/oauth2/authorization/kakao");
+    }
+
+    @Schema(description = "OAuth2 로그인 성공 응답")
+    record OAuth2LoginResponse(
+            @Schema(description = "JWT 액세스 토큰 (API 호출 시 Authorization: Bearer {accessToken} 헤더에 사용)")
+            String accessToken,
+            @Schema(description = "JWT 리프레시 토큰 (액세스 토큰 만료 시 갱신용)")
+            String refreshToken,
+            @Schema(description = "기존 가입 유저 여부 (false = 신규, true = 기존 가입)")
+            boolean isUser
+    ) {}
+}

--- a/src/main/java/com/deadlock/hellocs/user/adapter/in/web/UserController.java
+++ b/src/main/java/com/deadlock/hellocs/user/adapter/in/web/UserController.java
@@ -1,6 +1,7 @@
 package com.deadlock.hellocs.user.adapter.in.web;
 
 import com.deadlock.hellocs.global.jwt.JwtTokenProvider;
+import com.deadlock.hellocs.user.adapter.in.web.docs.UserControllerDocs;
 import com.deadlock.hellocs.user.application.port.in.CreateUserUseCase;
 import com.deadlock.hellocs.user.application.port.in.LoadUserUseCase;
 import com.deadlock.hellocs.user.application.port.in.ManageUserUseCase;
@@ -19,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
-public class UserController {
+public class UserController implements UserControllerDocs {
 
     private final CreateUserUseCase createUserUseCase;
     private final LoadUserUseCase loadUserUseCase;

--- a/src/main/java/com/deadlock/hellocs/user/adapter/in/web/docs/UserControllerDocs.java
+++ b/src/main/java/com/deadlock/hellocs/user/adapter/in/web/docs/UserControllerDocs.java
@@ -1,0 +1,114 @@
+package com.deadlock.hellocs.user.adapter.in.web.docs;
+
+import com.deadlock.hellocs.global.apiPayload.ApiResponse;
+import com.deadlock.hellocs.user.application.port.in.dto.ProfileResult;
+import com.deadlock.hellocs.user.application.port.in.dto.UpdateMyInfoCommand;
+import com.deadlock.hellocs.user.application.port.in.dto.UserSignUpCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "User", description = "사용자 API")
+public interface UserControllerDocs {
+
+    @Operation(summary = "회원가입", description = "카카오 OAuth2 인증 후 사용자 프로필을 등록합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 검증 실패",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 가입된 사용자(USER409_1) 또는 닉네임 중복(USER409)",
+                    content = @Content
+            )
+    })
+    ApiResponse<Void> createUser(
+            @RequestBody @Valid UserSignUpCommand command,
+            @Parameter(hidden = true) @AuthenticationPrincipal Jwt jwtUser
+    );
+
+    @Operation(summary = "내 프로필 조회", description = "현재 로그인한 사용자의 프로필 정보를 조회합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음(USER404)",
+                    content = @Content
+            )
+    })
+    ApiResponse<ProfileResult> getMyProfile(
+            @Parameter(hidden = true) @AuthenticationPrincipal Jwt jwtUser
+    );
+
+    @Operation(summary = "내 프로필 수정", description = "현재 로그인한 사용자의 닉네임, 프로필 이미지, 관심 주제를 수정합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 검증 실패",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음(USER404)",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "닉네임 중복(USER409)",
+                    content = @Content
+            )
+    })
+    ApiResponse<Void> updateMyProfile(
+            @RequestBody @Valid UpdateMyInfoCommand command,
+            @Parameter(hidden = true) @AuthenticationPrincipal Jwt jwtUser
+    );
+
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음(USER404)",
+                    content = @Content
+            )
+    })
+    ApiResponse<Void> deleteMyAccount(
+            @Parameter(hidden = true) @AuthenticationPrincipal Jwt jwtUser
+    );
+
+}


### PR DESCRIPTION
## Summary

>- closes #53 

UserController 및 OAuth2 인가 엔드포인트의 Swagger 문서 누락 항목을 보완

## Tasks

     - `UserControllerDocs` 인터페이스 작성 및 `UserController`에 적용
     - OAuth2 인가 엔드포인트 Swagger 노출을 위한
     `OAuth2AuthControllerDocs` 전용 컨트롤러 추가


## To Reviewer


## Screenshot

