### PR TITLE
feat: Topic 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/deadlock/hellocs/topic/adapter/in/web/TopicController.java
+++ b/src/main/java/com/deadlock/hellocs/topic/adapter/in/web/TopicController.java
@@ -1,0 +1,26 @@
+package com.deadlock.hellocs.topic.adapter.in.web;
+
+import com.deadlock.hellocs.global.apiPayload.ApiResponse;
+import com.deadlock.hellocs.topic.adapter.in.web.docs.TopicControllerDocs;
+import com.deadlock.hellocs.topic.application.port.in.LoadTopicUseCase;
+import com.deadlock.hellocs.topic.application.port.in.dto.TopicResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/topics")
+@RequiredArgsConstructor
+public class TopicController implements TopicControllerDocs {
+
+    private final LoadTopicUseCase loadTopicUseCase;
+
+    @GetMapping
+    @Override
+    public ApiResponse<List<TopicResult>> getAllTopics() {
+        return ApiResponse.onSuccess(loadTopicUseCase.getAllTopics());
+    }
+}

--- a/src/main/java/com/deadlock/hellocs/topic/adapter/in/web/docs/TopicControllerDocs.java
+++ b/src/main/java/com/deadlock/hellocs/topic/adapter/in/web/docs/TopicControllerDocs.java
@@ -1,0 +1,19 @@
+package com.deadlock.hellocs.topic.adapter.in.web.docs;
+
+import com.deadlock.hellocs.global.apiPayload.ApiResponse;
+import com.deadlock.hellocs.topic.application.port.in.dto.TopicResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.List;
+
+@Tag(name = "Topic", description = "주제 API")
+public interface TopicControllerDocs {
+
+    @Operation(summary = "전체 주제 목록 조회", description = "등록된 모든 주제(토픽) 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "주제 목록 조회 성공")
+    })
+    ApiResponse<List<TopicResult>> getAllTopics();
+}

--- a/src/main/java/com/deadlock/hellocs/topic/adapter/out/persistence/TopicPersistenceAdapter.java
+++ b/src/main/java/com/deadlock/hellocs/topic/adapter/out/persistence/TopicPersistenceAdapter.java
@@ -34,4 +34,11 @@ public class TopicPersistenceAdapter implements LoadTopicPort {
                 .map(TopicJpaEntity::toDomain)
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public List<Topic> loadAllTopics() {
+        return topicRepository.findAll().stream()
+                .map(TopicJpaEntity::toDomain)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/deadlock/hellocs/topic/application/port/in/LoadTopicUseCase.java
+++ b/src/main/java/com/deadlock/hellocs/topic/application/port/in/LoadTopicUseCase.java
@@ -1,9 +1,12 @@
 package com.deadlock.hellocs.topic.application.port.in;
 
+import com.deadlock.hellocs.topic.application.port.in.dto.TopicResult;
+
 import java.util.List;
 
 public interface LoadTopicUseCase {
     String getTopicName(Long id);
     List<String> getTopicNames(List<Long> ids);
     List<Long> getTopicIdsByNames(List<String> names);
+    List<TopicResult> getAllTopics();
 }

--- a/src/main/java/com/deadlock/hellocs/topic/application/port/in/dto/TopicResult.java
+++ b/src/main/java/com/deadlock/hellocs/topic/application/port/in/dto/TopicResult.java
@@ -1,0 +1,9 @@
+package com.deadlock.hellocs.topic.application.port.in.dto;
+
+import com.deadlock.hellocs.topic.domain.Topic;
+
+public record TopicResult(Long id, String name) {
+    public static TopicResult from(Topic topic) {
+        return new TopicResult(topic.getId(), topic.getName());
+    }
+}

--- a/src/main/java/com/deadlock/hellocs/topic/application/port/out/LoadTopicPort.java
+++ b/src/main/java/com/deadlock/hellocs/topic/application/port/out/LoadTopicPort.java
@@ -8,4 +8,5 @@ public interface LoadTopicPort {
     Optional<Topic> loadTopic(Long id);
     List<Topic> loadTopics(List<Long> ids);
     List<Topic> loadTopicsByNames(List<String> names);
+    List<Topic> loadAllTopics();
 }

--- a/src/main/java/com/deadlock/hellocs/topic/application/service/LoadTopicService.java
+++ b/src/main/java/com/deadlock/hellocs/topic/application/service/LoadTopicService.java
@@ -1,6 +1,7 @@
 package com.deadlock.hellocs.topic.application.service;
 
 import com.deadlock.hellocs.topic.application.port.in.LoadTopicUseCase;
+import com.deadlock.hellocs.topic.application.port.in.dto.TopicResult;
 import com.deadlock.hellocs.topic.application.port.out.LoadTopicPort;
 import com.deadlock.hellocs.topic.domain.Topic;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,13 @@ public class LoadTopicService implements LoadTopicUseCase {
     public List<Long> getTopicIdsByNames(List<String> names) {
         return loadTopicPort.loadTopicsByNames(names).stream()
                 .map(Topic::getId)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<TopicResult> getAllTopics() {
+        return loadTopicPort.loadAllTopics().stream()
+                .map(TopicResult::from)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Summary
- Topic 목록 조회 API (`GET /api/v1/topics`) 구현
- Hexagonal Architecture에 따라 Controller, UseCase, Port, Service, PersistenceAdapter 계층 구성
- Swagger 문서화를 위한 `TopicControllerDocs` 인터페이스 작성

## Related Issue
- closes #55

## Test plan
- [ ] `GET /api/v1/topics` 호출 시 전체 Topic 목록 정상 반환 확인
- [ ] Swagger UI에서 API 문서 정상 표시 확인
- [ ] 빈 Topic 목록일 때 빈 배열 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)