### PR TITLE
refactor: 인증 응답 DTO를 AuthTokenResponse로 통합 (#60)

### DIFF
--- a/src/main/java/com/deadlock/hellocs/global/auth/controller/AuthController.java
+++ b/src/main/java/com/deadlock/hellocs/global/auth/controller/AuthController.java
@@ -27,14 +27,14 @@ public class AuthController implements AuthControllerDocs {
     }
 
     @PostMapping("/reissue")
-    public ApiResponse<ReissueResponse> reissue(
+    public ApiResponse<AuthTokenResponse> reissue(
             @CookieValue("refreshToken") String refreshToken,
             HttpServletResponse response) {
 
         AuthService.TokenPair tokenPair = authService.reissueTokens(refreshToken);
         addRefreshTokenCookie(response, tokenPair.refreshToken());
 
-        return ApiResponse.onSuccess(new ReissueResponse(tokenPair.accessToken()));
+        return ApiResponse.onSuccess(new AuthTokenResponse(tokenPair.accessToken(), tokenPair.isUser()));
     }
 
     private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
@@ -54,6 +54,5 @@ public class AuthController implements AuthControllerDocs {
         // Swagger 명세 전용 엔드포인트입니다.
     }
 
-    public record ReissueResponse(String accessToken) {}
-    public record OAuth2TokenResponse(String accessToken, boolean isUser) {}
+    public record AuthTokenResponse(String accessToken, boolean isUser) {}
 }

--- a/src/main/java/com/deadlock/hellocs/global/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/deadlock/hellocs/global/auth/controller/docs/AuthControllerDocs.java
@@ -34,7 +34,7 @@ public interface AuthControllerDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",
                     description = "로그인 성공",
-                    content = @Content(schema = @Schema(implementation = AuthController.OAuth2TokenResponse.class))
+                    content = @Content(schema = @Schema(implementation = AuthController.AuthTokenResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "401",
@@ -63,6 +63,6 @@ public interface AuthControllerDocs {
                     content = @Content
             )
     })
-    ApiResponse<AuthController.ReissueResponse> reissue(String refreshToken,
+    ApiResponse<AuthController.AuthTokenResponse> reissue(String refreshToken,
                                                          HttpServletResponse response);
 }

--- a/src/main/java/com/deadlock/hellocs/global/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/deadlock/hellocs/global/auth/handler/OAuth2LoginSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.deadlock.hellocs.global.auth.handler;
 
+import com.deadlock.hellocs.global.auth.controller.AuthController;
 import com.deadlock.hellocs.global.auth.jwt.JwtTokenProvider;
 import com.deadlock.hellocs.user.application.port.in.LoadUserUseCase;
 import jakarta.servlet.http.HttpServletRequest;
@@ -42,7 +43,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         response.setContentType("application/json;charset=UTF-8");
         objectMapper.writeValue(response.getWriter(),
-                new OAuth2SuccessResponse(accessToken, isUser));
+                new AuthController.AuthTokenResponse(accessToken, isUser));
     }
 
     private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
@@ -55,6 +56,4 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
-
-    private record OAuth2SuccessResponse(String accessToken, boolean isUser) {}
 }

--- a/src/main/java/com/deadlock/hellocs/global/auth/service/AuthService.java
+++ b/src/main/java/com/deadlock/hellocs/global/auth/service/AuthService.java
@@ -19,11 +19,15 @@ public class AuthService {
     public TokenPair reissueTokens(String refreshToken) {
         Jwt decodedJwt = validateRefreshToken(refreshToken);
         String kakaoIdStr = decodedJwt.getSubject();
-        String role = getUserRole(Long.valueOf(kakaoIdStr));
+        Long kakaoId = Long.valueOf(kakaoIdStr);
+
+        boolean isUser = loadUserUseCase.isExist(kakaoId);
+        String role = isUser ? loadUserUseCase.getUserRole(kakaoId).name() : null;
 
         return new TokenPair(
                 jwtTokenProvider.createAccessToken(kakaoIdStr, role),
-                jwtTokenProvider.createRefreshToken(kakaoIdStr)
+                jwtTokenProvider.createRefreshToken(kakaoIdStr),
+                isUser
         );
     }
 
@@ -46,12 +50,5 @@ public class AuthService {
         }
     }
 
-    private String getUserRole(Long kakaoId) {
-        if (!loadUserUseCase.isExist(kakaoId)) {
-            throw new CustomException(ErrorStatus._USER_NOT_FOUND);
-        }
-        return loadUserUseCase.getUserRole(kakaoId).name();
-    }
-
-    public record TokenPair(String accessToken, String refreshToken) {}
+    public record TokenPair(String accessToken, String refreshToken, boolean isUser) {}
 }


### PR DESCRIPTION
Summary

관련 Issue: #60

Reissue 엔드포인트와 OAuth2LoginSuccessHandler가 서로 다른 응답 DTO를 사용하던 것을 AuthTokenResponse(accessToken, isUser)로 통합

Tasks
 ReissueResponse, OAuth2TokenResponse, OAuth2SuccessResponse → AuthTokenResponse로 통합
 AuthService.TokenPair에 isUser 필드 추가
 AuthService.reissueTokens() 로직을 OAuth2LoginSuccessHandler와 동일 패턴으로 변경
 Swagger 문서 타입 참조 업데이트