### PR TITLE
feat: AuthTokenResponse에 userData 필드 추가 (#62)

### DIFF
--- a/src/main/java/com/deadlock/hellocs/global/auth/controller/AuthController.java
+++ b/src/main/java/com/deadlock/hellocs/global/auth/controller/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController implements AuthControllerDocs {
         AuthService.TokenPair tokenPair = authService.reissueTokens(refreshToken);
         addRefreshTokenCookie(response, tokenPair.refreshToken());
 
-        return ApiResponse.onSuccess(new AuthTokenResponse(tokenPair.accessToken(), tokenPair.isUser()));
+        return ApiResponse.onSuccess(new AuthTokenResponse(tokenPair.accessToken(), tokenPair.isUser(), null));
     }
 
     private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
@@ -54,5 +54,7 @@ public class AuthController implements AuthControllerDocs {
         // Swagger 명세 전용 엔드포인트입니다.
     }
 
-    public record AuthTokenResponse(String accessToken, boolean isUser) {}
+    public record AuthTokenResponse(String accessToken, boolean isUser, UserData userData) {}
+
+    public record UserData(String nickname) {}
 }

--- a/src/main/java/com/deadlock/hellocs/global/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/deadlock/hellocs/global/auth/handler/OAuth2LoginSuccessHandler.java
@@ -1,6 +1,7 @@
 package com.deadlock.hellocs.global.auth.handler;
 
 import com.deadlock.hellocs.global.auth.controller.AuthController;
+import com.deadlock.hellocs.global.auth.controller.AuthController.UserData;
 import com.deadlock.hellocs.global.auth.jwt.JwtTokenProvider;
 import com.deadlock.hellocs.user.application.port.in.LoadUserUseCase;
 import jakarta.servlet.http.HttpServletRequest;
@@ -16,6 +17,7 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -41,9 +43,18 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         addRefreshTokenCookie(response, refreshToken);
 
+        UserData userData = isUser ? null : extractUserData(oAuth2User);
+
         response.setContentType("application/json;charset=UTF-8");
         objectMapper.writeValue(response.getWriter(),
-                new AuthController.AuthTokenResponse(accessToken, isUser));
+                new AuthController.AuthTokenResponse(accessToken, isUser, userData));
+    }
+
+    private UserData extractUserData(OAuth2User oAuth2User) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) oAuth2User.getAttributes().get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        String nickname = (String) profile.get("nickname");
+        return new UserData(nickname);
     }
 
     private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {

--- a/src/main/java/com/deadlock/hellocs/global/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/deadlock/hellocs/global/auth/handler/OAuth2LoginSuccessHandler.java
@@ -61,7 +61,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
                 .secure(true)
-                .path("/api/v1/auth")
+                .path("/")
                 .maxAge(Duration.ofMillis(jwtTokenProvider.getRefreshValidity()))
                 .sameSite("None")
                 .build();


### PR DESCRIPTION
## Summary

> 관련 Issue: #62

OAuth2 미가입 유저(`isUser == false`) 응답 시 카카오 닉네임을 전달하기 위해 `AuthTokenResponse`에 `userData` 필드를 추가하고, RefreshToken 쿠키 path를 루트(`/`)로 변경

## Tasks

- [x] `AuthTokenResponse`에 `UserData` inner record 추가
- [x] `OAuth2LoginSuccessHandler`: 미가입 유저일 때 카카오 닉네임을 `userData`에 담아 응답
- [x] `AuthController` reissue: 동일 DTO 구조 유지 (`userData: null`)
- [x] RefreshToken 쿠키 path `/` 로 변경 (프론트 요구사항)