### PR TITLE
feat: RefreshToken path 변경 및 Session 유지 방식 제거 (#64)

### DIFF
--- a/src/main/java/com/deadlock/hellocs/global/auth/controller/AuthController.java
+++ b/src/main/java/com/deadlock/hellocs/global/auth/controller/AuthController.java
@@ -41,7 +41,7 @@ public class AuthController implements AuthControllerDocs {
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
                 .secure(true)
-                .path("/api/v1/auth")
+                .path("/")
                 .maxAge(Duration.ofMillis(jwtTokenProvider.getRefreshValidity()))
                 .sameSite("None")
                 .build();

--- a/src/main/java/com/deadlock/hellocs/global/config/SecurityConfig.java
+++ b/src/main/java/com/deadlock/hellocs/global/config/SecurityConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 import org.springframework.web.cors.CorsConfiguration;
@@ -70,7 +72,8 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
-                .requestCache(RequestCacheConfigurer::disable);
+                .requestCache(RequestCacheConfigurer::disable)
+                .sessionManagement(SessionManagementConfigurer::disable);
     }
 
     @Bean


### PR DESCRIPTION
## Summary

> 관련 Issue: #64

- 프론트 요구사항에 따라 RefreshToken 쿠키 path를 `/api/v1/auth`에서 `/`로 변경
- 기존 OAuth2 state 검증을 위해 활성화했던 세션 관리를 독립 기능 확인 후 다시 제거

## Tasks

- [x] RefreshToken 쿠키 path `/`로 변경
- [x] `SessionManagementConfigurer::disable`로 세션 관리 완전 비활성화