### PR TITLE
feat: 채점 기록 목록 조회 API 구현 (#66)

### DIFF
--- a/src/main/java/com/deadlock/hellocs/quiz/grading/adapter/in/web/QuizGradingController.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/adapter/in/web/QuizGradingController.java
@@ -3,6 +3,7 @@ package com.deadlock.hellocs.quiz.grading.adapter.in.web;
 import com.deadlock.hellocs.global.apiPayload.ApiResponse;
 import com.deadlock.hellocs.quiz.grading.adapter.in.web.docs.QuizGradingControllerDocs;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingDetailLogResult;
+import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingLogListResult;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingLogResult;
 import com.deadlock.hellocs.quiz.grading.adapter.in.web.dto.SubmitAnswerResponse;
 import com.deadlock.hellocs.quiz.grading.application.port.in.QueryGradingLogInputPort;
@@ -62,6 +63,17 @@ public class QuizGradingController implements QuizGradingControllerDocs {
         Long requesterId = Long.valueOf(jwt.getSubject());
         return ApiResponse.onSuccess(
                 queryGradingLogInputPort.getGradingDetailLog(requesterId, new GetGradingDetailLogCommand(gradingLogId, quizId))
+        );
+    }
+
+    @GetMapping("/list")
+    @Override
+    public ApiResponse<List<GradingLogListResult>> getGradingLogList(
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+        Long requesterId = Long.valueOf(jwt.getSubject());
+        return ApiResponse.onSuccess(
+                queryGradingLogInputPort.getGradingLogList(requesterId)
         );
     }
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/grading/adapter/in/web/docs/QuizGradingControllerDocs.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/adapter/in/web/docs/QuizGradingControllerDocs.java
@@ -3,6 +3,7 @@ package com.deadlock.hellocs.quiz.grading.adapter.in.web.docs;
 import com.deadlock.hellocs.global.apiPayload.ApiResponse;
 import com.deadlock.hellocs.quiz.grading.adapter.in.web.dto.SubmitAnswerResponse;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingDetailLogResult;
+import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingLogListResult;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingLogResult;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.UserGradingCommand;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -115,5 +116,23 @@ public interface QuizGradingControllerDocs {
             String gradingLogId,
             @Parameter(description = "퀴즈 ID", required = true)
             Long quizId
+    );
+
+    @Operation(summary = "채점 기록 목록 조회", description = "자신의 전체 채점 기록 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "채점 기록 목록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content
+            )
+    })
+    ApiResponse<List<GradingLogListResult>> getGradingLogList(
+            @Parameter(hidden = true) Jwt jwt
     );
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/grading/adapter/out/persistence/GradingLogPersistenceAdapter.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/adapter/out/persistence/GradingLogPersistenceAdapter.java
@@ -9,6 +9,8 @@ import com.deadlock.hellocs.quiz.grading.domain.GradingLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class GradingLogPersistenceAdapter implements CommandGradingLogOutputPort, QueryGradingLogOutputPort {
@@ -25,5 +27,12 @@ public class GradingLogPersistenceAdapter implements CommandGradingLogOutputPort
         return gradingLogRepository.findById(id)
                 .map(GradingLogMongoEntity::toDomain)
                 .orElseThrow(() -> new CustomException(QuizErrorStatus.GRADING_LOG_NOT_FOUND));
+    }
+
+    @Override
+    public List<GradingLog> findAllByUserId(Long userId) {
+        return gradingLogRepository.findAllByUserId(userId).stream()
+                .map(GradingLogMongoEntity::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/grading/adapter/out/persistence/GradingLogRepository.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/adapter/out/persistence/GradingLogRepository.java
@@ -3,5 +3,8 @@ package com.deadlock.hellocs.quiz.grading.adapter.out.persistence;
 import com.deadlock.hellocs.quiz.grading.adapter.out.persistence.entity.GradingLogMongoEntity;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
+
 public interface GradingLogRepository extends MongoRepository<GradingLogMongoEntity, String> {
+    List<GradingLogMongoEntity> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/grading/adapter/out/persistence/entity/GradingLogMongoEntity.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/adapter/out/persistence/entity/GradingLogMongoEntity.java
@@ -2,6 +2,7 @@ package com.deadlock.hellocs.quiz.grading.adapter.out.persistence.entity;
 
 import com.deadlock.hellocs.quiz.grading.domain.GradingItem;
 import com.deadlock.hellocs.quiz.grading.domain.GradingLog;
+import com.deadlock.hellocs.quiz.shared.domain.QuizMode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,6 +26,8 @@ public class GradingLogMongoEntity {
     private int totalCount;
     private int correctCount;
     private List<GradingItem> results;
+    private QuizMode quizMode;
+    private List<String> topicNames;
 
     public GradingLog toDomain() {
         return GradingLog.builder()
@@ -34,6 +37,8 @@ public class GradingLogMongoEntity {
                 .totalCount(totalCount)
                 .correctCount(correctCount)
                 .results(results)
+                .quizMode(quizMode)
+                .topicNames(topicNames)
                 .build();
     }
 
@@ -45,6 +50,8 @@ public class GradingLogMongoEntity {
                 .totalCount(gradingLog.getTotalCount())
                 .correctCount(gradingLog.getCorrectCount())
                 .results(gradingLog.getResults())
+                .quizMode(gradingLog.getQuizMode())
+                .topicNames(gradingLog.getTopicNames())
                 .build();
     }
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/grading/application/port/in/QueryGradingLogInputPort.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/application/port/in/QueryGradingLogInputPort.java
@@ -3,10 +3,14 @@ package com.deadlock.hellocs.quiz.grading.application.port.in;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GetGradingDetailLogCommand;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GetGradingLogCommand;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingDetailLogResult;
+import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingLogListResult;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingLogResult;
 import jakarta.validation.Valid;
+
+import java.util.List;
 
 public interface QueryGradingLogInputPort {
     GradingLogResult getGradingLog(Long requesterId, @Valid GetGradingLogCommand command);
     GradingDetailLogResult getGradingDetailLog(Long requesterId, @Valid GetGradingDetailLogCommand command);
+    List<GradingLogListResult> getGradingLogList(Long requesterId);
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/grading/application/port/in/dto/GradingLogListResult.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/application/port/in/dto/GradingLogListResult.java
@@ -1,0 +1,34 @@
+package com.deadlock.hellocs.quiz.grading.application.port.in.dto;
+
+import com.deadlock.hellocs.quiz.grading.domain.GradingLog;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GradingLogListResult(
+        String id,
+        LocalDateTime solvedAt,
+        int correctCount,
+        int totalCount,
+        String quizMode,
+        List<String> topicNames
+) {
+    public static GradingLogListResult from(GradingLog gradingLog) {
+        String mode = gradingLog.getQuizMode() != null
+                ? gradingLog.getQuizMode().name()
+                : null;
+
+        List<String> topics = gradingLog.getTopicNames() != null
+                ? gradingLog.getTopicNames()
+                : List.of();
+
+        return new GradingLogListResult(
+                gradingLog.getId(),
+                gradingLog.getSolvedAt(),
+                gradingLog.getCorrectCount(),
+                gradingLog.getTotalCount(),
+                mode,
+                topics
+        );
+    }
+}

--- a/src/main/java/com/deadlock/hellocs/quiz/grading/application/port/out/QueryGradingLogOutputPort.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/application/port/out/QueryGradingLogOutputPort.java
@@ -1,8 +1,10 @@
 package com.deadlock.hellocs.quiz.grading.application.port.out;
 
 import com.deadlock.hellocs.quiz.grading.domain.GradingLog;
-import java.util.Optional;
+
+import java.util.List;
 
 public interface QueryGradingLogOutputPort {
     GradingLog findById(String id);
+    List<GradingLog> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/grading/application/service/GradingCommandService.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/application/service/GradingCommandService.java
@@ -12,6 +12,8 @@ import com.deadlock.hellocs.quiz.grading.domain.GradingLog;
 import com.deadlock.hellocs.quiz.grading.domain.GradingItem;
 import com.deadlock.hellocs.quiz.quiz.application.port.out.QueryQuizOutputPort;
 import com.deadlock.hellocs.quiz.quiz.domain.Quiz;
+import com.deadlock.hellocs.topic.application.port.in.LoadTopicUseCase;
+import com.deadlock.hellocs.quiz.shared.domain.QuizMode;
 import com.deadlock.hellocs.quiz.shared.domain.QuizType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -42,6 +44,7 @@ public class GradingCommandService implements CommandAnswerInputPort {
     private final CommandGradingLogOutputPort commandGradingLogPort;
     private final List<GradingPolicy> gradingPolicies;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final LoadTopicUseCase loadTopicUseCase;
     
     @Override
     public String submit(SubmitAnswersCommand command) {
@@ -61,8 +64,12 @@ public class GradingCommandService implements CommandAnswerInputPort {
         // 3. 채점 수행 (각 퀴즈 타입에 맞는 정책 적용)
         List<GradingItem> gradingItems = gradeAnswers(answers, quizzes);
 
-        // 4. 채점 로그 생성 및 저장
-        GradingLog gradingLog = GradingLog.create(userId, gradingItems);
+        // 4. 메타데이터 추론
+        QuizMode quizMode = inferQuizMode(quizzes);
+        List<String> topicNames = collectTopicNames(quizzes);
+
+        // 5. 채점 로그 생성 및 저장
+        GradingLog gradingLog = GradingLog.create(userId, gradingItems, quizMode, topicNames);
         GradingLog savedGradingLog = commandGradingLogPort.save(gradingLog);
 
         applicationEventPublisher.publishEvent(new GradingCompletedEvent(
@@ -130,5 +137,19 @@ public class GradingCommandService implements CommandAnswerInputPort {
                 .filter(policy -> policy.supports(quizType))
                 .findFirst()
                 .orElseThrow(() -> new CustomException(QuizErrorStatus.GRADING_POLICY_NOT_FOUND));
+    }
+
+    private QuizMode inferQuizMode(List<Quiz> quizzes) {
+        boolean allVoice = quizzes.stream()
+                .allMatch(quiz -> quiz.getType() == QuizType.VOICE);
+        return allVoice ? QuizMode.VOICE : QuizMode.STANDARD;
+    }
+
+    private List<String> collectTopicNames(List<Quiz> quizzes) {
+        List<Long> topicIds = quizzes.stream()
+                .flatMap(quiz -> quiz.getTopicIds().stream())
+                .distinct()
+                .toList();
+        return loadTopicUseCase.getTopicNames(topicIds);
     }
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/grading/application/service/GradingQueryService.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/application/service/GradingQueryService.java
@@ -6,6 +6,7 @@ import com.deadlock.hellocs.quiz.grading.application.port.in.QueryGradingLogInpu
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GetGradingDetailLogCommand;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GetGradingLogCommand;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingDetailLogResult;
+import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingLogListResult;
 import com.deadlock.hellocs.quiz.grading.application.port.in.dto.GradingLogResult;
 import com.deadlock.hellocs.quiz.grading.application.port.out.QueryGradingLogOutputPort;
 import com.deadlock.hellocs.quiz.grading.domain.GradingLog;
@@ -69,6 +70,13 @@ public class GradingQueryService implements QueryGradingLogInputPort {
 
         return GradingDetailLogResult.from(result, quiz);
     }
+    @Override
+    public List<GradingLogListResult> getGradingLogList(Long requesterId) {
+        return queryGradingLogPort.findAllByUserId(requesterId).stream()
+                .map(GradingLogListResult::from)
+                .toList();
+    }
+
     // --- Helper Methods ---
 
     private void validateOwnership(GradingLog gradingLog, Long userId) {

--- a/src/main/java/com/deadlock/hellocs/quiz/grading/domain/GradingLog.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/grading/domain/GradingLog.java
@@ -1,5 +1,6 @@
 package com.deadlock.hellocs.quiz.grading.domain;
 
+import com.deadlock.hellocs.quiz.shared.domain.QuizMode;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,8 +16,11 @@ public class GradingLog {
     private int totalCount;
     private int correctCount;
     private List<GradingItem> results;
+    private QuizMode quizMode;
+    private List<String> topicNames;
 
-    public static GradingLog create(Long userId, List<GradingItem> results) {
+    public static GradingLog create(Long userId, List<GradingItem> results,
+                                    QuizMode quizMode, List<String> topicNames) {
         int correctCount = (int) results.stream()
                 .filter(GradingItem::isCorrect)
                 .count();
@@ -27,6 +31,8 @@ public class GradingLog {
                 .totalCount(results.size())
                 .correctCount(correctCount)
                 .results(results)
+                .quizMode(quizMode)
+                .topicNames(topicNames)
                 .build();
     }
 }


### PR DESCRIPTION
## Summary

> 관련 Issue: #66

채점 기록 목록 조회 API (`GET /v1/quiz/grading/list`)를 구현합니다.
- GradingLog 도메인에 quizMode, topicNames 메타데이터 추가 (채점 시 퀴즈로부터 추론)
- 사용자 본인의 전체 채점 기록을 리스트로 반환

Closes #66

## Tasks

- [x] `GradingLog` 도메인에 `quizMode`, `topicNames` 필드 추가
- [x] `GradingLogMongoEntity` 필드 및 매핑 확장
- [x] `GradingCommandService`에서 채점 시 메타데이터 추론 로직 추가
- [x] `GradingLogListResult` 응답 DTO 생성
- [x] `QueryGradingLogInputPort` / `QueryGradingLogOutputPort` 목록 조회 메서드 추가
- [x] `GradingQueryService` 목록 조회 구현
- [x] `GradingLogRepository` / `GradingLogPersistenceAdapter` userId 기반 조회 구현
- [x] `QuizGradingController` 엔드포인트 추가 + Swagger 문서화