### PR TITLE
feat: 풀었던 퀴즈 제외 및 랜덤 제공 로직 구현 (#68)

### DIFF
--- a/src/main/java/com/deadlock/hellocs/quiz/quiz/adapter/in/web/QuizController.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/quiz/adapter/in/web/QuizController.java
@@ -30,6 +30,6 @@ public class QuizController implements QuizControllerDocs {
         Long kakaoId = Long.valueOf(jwtUser.getSubject());
         QuizLevel userLevel = loadUserUseCase.getUserLevel(kakaoId);
         GetQuizCommand request = new GetQuizCommand(userLevel, getQuizRequest.topicIds(), getQuizRequest.mode());
-        return ApiResponse.onSuccess(queryQuizInputPort.getQuizzes(request));
+        return ApiResponse.onSuccess(queryQuizInputPort.getQuizzes(request, kakaoId));
     }
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/quiz/adapter/out/persistence/QuizPersistenceAdapter.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/quiz/adapter/out/persistence/QuizPersistenceAdapter.java
@@ -36,6 +36,17 @@ public class QuizPersistenceAdapter implements QueryQuizOutputPort {
     }
 
     @Override
+    public List<Quiz> findQuizzesByCriteria(
+            QuizLevel level,
+            List<Long> topicIds,
+            QuizType type
+    ) {
+        return quizRepository.findByLevelAndTypeAndTopicIds(level, type, topicIds).stream()
+                .map(QuizJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
     public Quiz findById(Long quizId) {
         return quizRepository.findById(quizId)
                 .map(QuizJpaEntity::toDomain)

--- a/src/main/java/com/deadlock/hellocs/quiz/quiz/application/policy/QuizGenerationPolicy.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/quiz/application/policy/QuizGenerationPolicy.java
@@ -28,5 +28,5 @@ public interface QuizGenerationPolicy {
      * @param queryQuizPort 퀴즈 조회 포트
      * @return 생성된 Quiz 리스트
      */
-    List<Quiz> generate(GetQuizCommand command, QueryQuizOutputPort queryQuizPort);
+    List<Quiz> generate(GetQuizCommand command, QueryQuizOutputPort queryQuizPort, Long userId);
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/quiz/application/policy/StandardQuizGenerationPolicy.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/quiz/application/policy/StandardQuizGenerationPolicy.java
@@ -1,15 +1,21 @@
 package com.deadlock.hellocs.quiz.quiz.application.policy;
 
+import com.deadlock.hellocs.quiz.grading.application.port.out.QueryGradingLogOutputPort;
+import com.deadlock.hellocs.quiz.grading.domain.GradingItem;
 import com.deadlock.hellocs.quiz.quiz.application.port.in.dto.GetQuizCommand;
 import com.deadlock.hellocs.quiz.quiz.application.port.out.QueryQuizOutputPort;
 import com.deadlock.hellocs.quiz.quiz.domain.Quiz;
 import com.deadlock.hellocs.quiz.shared.domain.QuizMode;
 import com.deadlock.hellocs.quiz.shared.domain.QuizType;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 표준 Quiz 생성 정책
@@ -17,6 +23,7 @@ import java.util.Map;
  * OX 2개 + 객관식 2개 + 단답형 1개 = 총 5개
  */
 @Component
+@RequiredArgsConstructor
 public class StandardQuizGenerationPolicy implements QuizGenerationPolicy {
 
     private static final Map<QuizType, Integer> COMPOSITION = Map.of(
@@ -24,24 +31,34 @@ public class StandardQuizGenerationPolicy implements QuizGenerationPolicy {
             QuizType.MULTIPLE_CHOICE, 2,
             QuizType.SHORT_ANSWER, 1
     );
-    
+
+    private final QueryGradingLogOutputPort queryGradingLogPort;
+
     @Override
     public boolean supports(QuizMode mode) {
         return mode == QuizMode.STANDARD;
     }
-    
+
     @Override
-    public List<Quiz> generate(GetQuizCommand command, QueryQuizOutputPort queryQuizPort) {
+    public List<Quiz> generate(GetQuizCommand command, QueryQuizOutputPort queryQuizPort, Long userId) {
+        Set<Long> solvedQuizIds = queryGradingLogPort.findAllByUserId(userId).stream()
+                .flatMap(log -> log.getResults().stream())
+                .map(GradingItem::quizId)
+                .collect(Collectors.toSet());
+
         List<Quiz> quizzes = new ArrayList<>();
 
         COMPOSITION.forEach((type, count) -> {
-            List<Quiz> foundQuizzes = queryQuizPort.findQuizzesByCriteria(
+            List<Quiz> candidates = queryQuizPort.findQuizzesByCriteria(
                     command.level(),
                     command.topicIds(),
-                    type,
-                    count
+                    type
             );
-            quizzes.addAll(foundQuizzes);
+            List<Quiz> filtered = candidates.stream()
+                    .filter(q -> !solvedQuizIds.contains(q.getId()))
+                    .collect(Collectors.toCollection(ArrayList::new));
+            Collections.shuffle(filtered);
+            quizzes.addAll(filtered.stream().limit(count).toList());
         });
 
         return quizzes;

--- a/src/main/java/com/deadlock/hellocs/quiz/quiz/application/policy/VoiceQuizGenerationPolicy.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/quiz/application/policy/VoiceQuizGenerationPolicy.java
@@ -1,15 +1,21 @@
 package com.deadlock.hellocs.quiz.quiz.application.policy;
 
+import com.deadlock.hellocs.quiz.grading.application.port.out.QueryGradingLogOutputPort;
+import com.deadlock.hellocs.quiz.grading.domain.GradingItem;
 import com.deadlock.hellocs.quiz.quiz.application.port.in.dto.GetQuizCommand;
 import com.deadlock.hellocs.quiz.quiz.application.port.out.QueryQuizOutputPort;
 import com.deadlock.hellocs.quiz.quiz.domain.Quiz;
 import com.deadlock.hellocs.quiz.shared.domain.QuizMode;
 import com.deadlock.hellocs.quiz.shared.domain.QuizType;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 음성 Quiz 생성 정책
@@ -17,29 +23,40 @@ import java.util.Map;
  * Voice 3개
  */
 @Component
+@RequiredArgsConstructor
 public class VoiceQuizGenerationPolicy implements QuizGenerationPolicy {
 
     private static final Map<QuizType, Integer> COMPOSITION = Map.of(
             QuizType.VOICE, 3
     );
-    
+
+    private final QueryGradingLogOutputPort queryGradingLogPort;
+
     @Override
     public boolean supports(QuizMode mode) {
         return mode == QuizMode.VOICE;
     }
-    
+
     @Override
-    public List<Quiz> generate(GetQuizCommand command, QueryQuizOutputPort queryQuizPort) {
+    public List<Quiz> generate(GetQuizCommand command, QueryQuizOutputPort queryQuizPort, Long userId) {
+        Set<Long> solvedQuizIds = queryGradingLogPort.findAllByUserId(userId).stream()
+                .flatMap(log -> log.getResults().stream())
+                .map(GradingItem::quizId)
+                .collect(Collectors.toSet());
+
         List<Quiz> quizzes = new ArrayList<>();
 
         COMPOSITION.forEach((type, count) -> {
-            List<Quiz> foundQuizzes = queryQuizPort.findQuizzesByCriteria(
+            List<Quiz> candidates = queryQuizPort.findQuizzesByCriteria(
                     command.level(),
                     command.topicIds(),
-                    type,
-                    count
+                    type
             );
-            quizzes.addAll(foundQuizzes);
+            List<Quiz> filtered = candidates.stream()
+                    .filter(q -> !solvedQuizIds.contains(q.getId()))
+                    .collect(Collectors.toCollection(ArrayList::new));
+            Collections.shuffle(filtered);
+            quizzes.addAll(filtered.stream().limit(count).toList());
         });
 
         return quizzes;

--- a/src/main/java/com/deadlock/hellocs/quiz/quiz/application/port/in/QueryQuizInputPort.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/quiz/application/port/in/QueryQuizInputPort.java
@@ -7,5 +7,5 @@ import jakarta.validation.constraints.NotNull;
 
 
 public interface QueryQuizInputPort {
-    GetQuizResult getQuizzes(@NotNull @Valid GetQuizCommand request);
+    GetQuizResult getQuizzes(@NotNull @Valid GetQuizCommand request, Long userId);
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/quiz/application/port/out/QueryQuizOutputPort.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/quiz/application/port/out/QueryQuizOutputPort.java
@@ -14,6 +14,11 @@ public interface QueryQuizOutputPort {
             QuizType type,
             int count
     );
+    List<Quiz> findQuizzesByCriteria(
+            QuizLevel level,
+            List<Long> topicIds,
+            QuizType type
+    );
     Quiz findById(Long quizId);
     List<Quiz> findAllByIds(List<Long> quizIds);
 }

--- a/src/main/java/com/deadlock/hellocs/quiz/quiz/application/service/QuizService.java
+++ b/src/main/java/com/deadlock/hellocs/quiz/quiz/application/service/QuizService.java
@@ -35,9 +35,9 @@ public class QuizService implements QueryQuizInputPort {
     private final QueryQuizOutputPort queryQuizPort;
 
     @Override
-    public GetQuizResult getQuizzes(GetQuizCommand request) {
+    public GetQuizResult getQuizzes(GetQuizCommand request, Long userId) {
         QuizGenerationPolicy policy = getGenerationPolicy(request.mode());
-        return mapToGetQuizResult(policy.generate(request, queryQuizPort));
+        return mapToGetQuizResult(policy.generate(request, queryQuizPort, userId));
     }
 
     private QuizGenerationPolicy getGenerationPolicy(QuizMode mode) {

--- a/src/test/java/com/deadlock/hellocs/quiz/quiz/adapter/in/web/QuizControllerTest.java
+++ b/src/test/java/com/deadlock/hellocs/quiz/quiz/adapter/in/web/QuizControllerTest.java
@@ -70,7 +70,7 @@ class QuizControllerTest {
         );
 
         given(loadUserUseCase.getUserLevel(12345L)).willReturn(QuizLevel.PRO);
-        given(queryQuizInputPort.getQuizzes(eq(new GetQuizCommand(QuizLevel.PRO, List.of(10L, 20L), QuizMode.STANDARD))))
+        given(queryQuizInputPort.getQuizzes(eq(new GetQuizCommand(QuizLevel.PRO, List.of(10L, 20L), QuizMode.STANDARD)), eq(12345L)))
                 .willReturn(result);
 
         mockMvc.perform(post("/v1/quiz")
@@ -92,7 +92,7 @@ class QuizControllerTest {
 
         then(loadUserUseCase).should().getUserLevel(12345L);
         then(queryQuizInputPort).should()
-                .getQuizzes(new GetQuizCommand(QuizLevel.PRO, List.of(10L, 20L), QuizMode.STANDARD));
+                .getQuizzes(new GetQuizCommand(QuizLevel.PRO, List.of(10L, 20L), QuizMode.STANDARD), 12345L);
     }
 
     @Test


### PR DESCRIPTION
## Summary

> 관련 Issue: #68

퀴즈 생성 시 사용자가 이미 풀었던 퀴즈를 제외하고, 남은 퀴즈 중 랜덤으로 제공하도록 개선

## Tasks

- [x] QuizGenerationPolicy 인터페이스에 userId 파라미터 추가
- [x] StandardQuizGenerationPolicy에 풀었던 퀴즈 제외 + 랜덤 셔플 로직 구현
- [x] VoiceQuizGenerationPolicy에 동일 로직 적용
- [x] QueryQuizOutputPort에 count 없이 전체 조회하는 오버로드 메서드 추가
- [x] Controller → Service → Policy까지 userId 전달 경로 구성
- [x] 테스트 코드 시그니처 변경 반영